### PR TITLE
Update metadata with runtime and engine specs

### DIFF
--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -6,6 +6,16 @@ prototype_version: 1.0
 date: "2020-09-29"
 api_version: 1
 
+engine_images:
+  - image_name: engine
+    tags:
+      - 14-cml-2021.05-1
+
+runtimes:
+  - editor: Workbench
+    kernel: Python 3.6
+    edition: Standard
+
 tasks:
   - type: create_job
     name: Install dependencies


### PR DESCRIPTION
Tested on CDP Public Cloud for specified runtime (version 2020.11) and engine.